### PR TITLE
[IA-2543] adding network policy

### DIFF
--- a/terra-app-setup-chart/Chart.yaml
+++ b/terra-app-setup-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: terra-app-setup
 description: Chart for set up entities for deploying Terra applications
 type: application
-version: 0.0.1
+version: 0.0.2

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -5,28 +5,30 @@ helm install  --set serviceAccount.annotations.gcpServiceAccount="<value>" -n <n
 # Publish Chart
 For publishing a new version to prod, at project root, run the following commands.
 Note for these changes to take effect in leonardo you will need to update the version in the Dockerfile and reference.conf 
-
+It is very important to re-copy the index.yaml from the remote every time you index the chart
 ```
 helm package terra-app-setup-chart
+rm -rf terra-app-setup-chart/repo
 mkdir terra-app-setup-chart/repo
-gsutil cp -r gs://terra-app-setup-chart terra-app-setup-chart/repo/
-mv terra-app-setup-[Version in Chart.yaml].tgz terra-app-setup-chart/repo/terra-app-setup-chart
-helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-setup-chart --merge terra-app-setup-chart/repo/terra-app-setup-chart/index.yaml
-gsutil cp -r terra-app-setup-chart/repo/terra-app-setup-chart/* gs://terra-app-setup-chart
+gsutil cp -r gs://terra-app-setup-chart/index.yaml terra-app-setup-chart/repo
+mv terra-app-setup-[Version in Chart.yaml].tgz terra-app-setup-chart/repo
+helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-setup-chart --merge terra-app-setup-chart/repo/index.yaml
+gsutil cp -r terra-app-setup-chart/repo/* gs://terra-app-setup-chart
 ```
 
 For developing locally
 
 Run this locally to publish your changes (this will not overwrite the version used in prod due to the --merge option).
+It is very important to re-copy the index.yaml from the remote every time you index the chart
 ```
 VERSION=[Version in Chart.yaml]
 helm package terra-app-setup-chart
 rm -rf terra-app-setup-chart/repo
 mkdir -p terra-app-setup-chart/repo
-gsutil cp -r gs://terra-app-setup-chart terra-app-setup-chart/repo
-mv terra-app-setup-$VERSION.tgz terra-app-setup-chart/repo/terra-app-setup-chart
-helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-dev --merge terra-app-setup-chart/repo/terra-app-setup-chart/index.yaml
-gsutil cp -r terra-app-setup-chart/repo/terra-app-setup-chart/* gs://terra-app-setup-chart
+gsutil cp -r gs://terra-app-setup-chart/index.yaml terra-app-setup-chart/repo
+mv terra-app-setup-$VERSION.tgz terra-app-setup-chart/repo
+helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-dev --merge terra-app-setup-chart/repo/index.yaml
+gsutil cp -r terra-app-setup-chart/repo/* gs://terra-app-setup-chart
 ```
 
 Now, to get leo to use your chart, Run this in your fiab, while you are in the leonardo docker image.

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -46,7 +46,7 @@ cd leonardo
 rm  -rf terra-app-setup # will fail, its ok
 helm pull terra-app-setup-charts/terra-app-setup --version $VERSION 
 mkdir temp
-tar -xf terra-app-setup-$VERSION.tgz -C temp --strip-components=app_1
+tar -xf terra-app-setup-$VERSION.tgz -C temp --strip-components=1
 cp temp/* terra-app-setup-charts #will fail, its ok
 ```
 

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -3,12 +3,55 @@
 helm install  --set serviceAccount.annotations.gcpServiceAccount="<value>" -n <namespace> <release-name> ./terra-app-setup-chart
 ```
 # Publish Chart
-At project root, run the following commands
+For publishing a new version to prod, at project root, run the following commands
 
 ```
 helm package terra-app-setup-chart
 mkdir terra-app-setup-chart/repo
-mv terra-app-setup-0.0.1.tgz terra-app-setup-chart/repo
-helm repo index terra-app-setup-chart/repo/ --url https://storage.googleapis.com/terra-app-setup-chart
-gsutil cp -r terra-app-setup-chart/repo/* gs://terra-app-setup-chart
+gsutil cp -r gs://terra-app-setup-chart terra-app-setup-chart/repo/
+mv terra-app-setup-[Version in Chart.yaml].tgz terra-app-setup-chart/repo/terra-app-setup-chart
+helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-setup-chart --merge terra-app-setup-chart/repo/terra-app-setup-chart/index.yaml
+gsutil cp -r terra-app-setup-chart/repo/terra-app-setup-chart/* gs://terra-app-setup-chart
 ```
+
+For developing locally
+
+Run this locally to publish your changes (this will not overwrite the version used in prod due to the --merge option).
+```
+VERSION=[Version in Chart.yaml]
+helm package terra-app-setup-chart
+rm -rf terra-app-setup-chart/repo
+mkdir -p terra-app-setup-chart/repo
+gsutil cp -r gs://terra-app-setup-chart terra-app-setup-chart/repo
+mv terra-app-setup-$VERSION.tgz terra-app-setup-chart/repo/terra-app-setup-chart
+helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/terra-app-dev --merge terra-app-setup-chart/repo/terra-app-setup-chart/index.yaml
+gsutil cp -r terra-app-setup-chart/repo/terra-app-setup-chart/* gs://terra-app-setup-chart
+```
+
+Now, to get leo to use your chart, Run this in your fiab, while you are in the leonardo docker image
+```
+VERSION=[Version in Chart.yaml]
+cd leonardo
+rm  -rf terra-app-setup
+helm pull terra-app-setup-charts/terra-app-setup --version $VERSION --untar
+```
+
+Now, add the following to `/etc/leonardo.conf` in the leonardo docker image within your fiab
+```
+terra-app-setup-chart {
+  chart-name = "/leonardo/terra-app-setup"
+  chart-version = "[your version here]"
+}
+```
+
+Next, restart leonardo in your fiab via
+```
+exit
+docker restart firecloud_leonardo-app_1 
+```
+
+Apps you create via your fiab leonardo will now use the appropriate chart
+
+
+
+

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -3,7 +3,8 @@
 helm install  --set serviceAccount.annotations.gcpServiceAccount="<value>" -n <namespace> <release-name> ./terra-app-setup-chart
 ```
 # Publish Chart
-For publishing a new version to prod, at project root, run the following commands
+For publishing a new version to prod, at project root, run the following commands.
+Note for these changes to take effect in leonardo you will need to update the version in the Dockerfile and reference.conf 
 
 ```
 helm package terra-app-setup-chart

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -28,12 +28,25 @@ helm repo index terra-app-setup-chart/repo --url https://storage.googleapis.com/
 gsutil cp -r terra-app-setup-chart/repo/terra-app-setup-chart/* gs://terra-app-setup-chart
 ```
 
-Now, to get leo to use your chart, Run this in your fiab, while you are in the leonardo docker image
+Now, to get leo to use your chart, Run this in your fiab, while you are in the leonardo docker image.
+Note that if you already have a running app, the rm will fail because the certs are in use. See subsequent set of commands.
+
+If no apps are running:
 ```
 VERSION=[Version in Chart.yaml]
 cd leonardo
 rm  -rf terra-app-setup
 helm pull terra-app-setup-charts/terra-app-setup --version $VERSION --untar
+```
+If an app is running:
+```
+VERSION=[Version in Chart.yaml]
+cd leonardo
+rm  -rf terra-app-setup # will fail, its ok
+helm pull terra-app-setup-charts/terra-app-setup --version $VERSION 
+mkdir temp
+tar -xf terra-app-setup-$VERSION.tgz -C temp --strip-components=app_1
+cp temp/* terra-app-setup-charts #will fail, its ok
 ```
 
 Now, add the following to `/etc/leonardo.conf` in the leonardo docker image within your fiab

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -42,7 +42,7 @@ helm pull terra-app-setup-charts/terra-app-setup --version $VERSION --untar
 If an app is running:
 ```
 VERSION=[Version in Chart.yaml]
-cd leonardo # comment
+cd leonardo
 rm  -rf terra-app-setup # will fail, its ok
 helm pull terra-app-setup-charts/terra-app-setup --version $VERSION 
 mkdir temp

--- a/terra-app-setup-chart/README.md
+++ b/terra-app-setup-chart/README.md
@@ -42,12 +42,12 @@ helm pull terra-app-setup-charts/terra-app-setup --version $VERSION --untar
 If an app is running:
 ```
 VERSION=[Version in Chart.yaml]
-cd leonardo
+cd leonardo # comment
 rm  -rf terra-app-setup # will fail, its ok
 helm pull terra-app-setup-charts/terra-app-setup --version $VERSION 
 mkdir temp
 tar -xf terra-app-setup-$VERSION.tgz -C temp --strip-components=1
-cp temp/* terra-app-setup-charts #will fail, its ok
+cp temp/* terra-app-setup #will fail, its ok
 ```
 
 Now, add the following to `/etc/leonardo.conf` in the leonardo docker image within your fiab

--- a/terra-app-setup-chart/templates/network-policy.yaml
+++ b/terra-app-setup-chart/templates/network-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: deny-from-other-namespaces
+  name: deny-ingress-from-other-namespaces
   namespace: {{ .Release.Namespace  }}
 spec:
   podSelector:
@@ -12,3 +12,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           name: nginx
+  egress:
+  - {}
+  policyTypes:
+  - Egress

--- a/terra-app-setup-chart/templates/network-policy.yaml
+++ b/terra-app-setup-chart/templates/network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-from-other-namespaces
+  namespace: {{ .Release.Namespace  }}
+spec:
+  podSelector:
+    matchLabels:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          name: nginx


### PR DESCRIPTION
I still need to do the following after this PR:

- Publish version 0.0.2
- Explicitly peg the new version in leonardo docker image, and update reference.conf

I tested this in my fiab with a manually published SNAP chart, and manually deployed the network policy yaml to a working dev galaxy, and confirmed proxying still worked after. 

I also did all tests detailed in the design doc with this yaml: https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/1401094202/2021-02-16+Kubernetes+Network+Policy+in+apps

