### PR TITLE
Attempt to make setup chart support azure and gcp

### DIFF
--- a/terra-app-setup-chart/Chart.yaml
+++ b/terra-app-setup-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: terra-app-setup
 description: Chart for set up entities for deploying Terra applications
 type: application
-version: 0.0.2
+version: 0.0.3

--- a/terra-app-setup-chart/templates/network-policy.yaml
+++ b/terra-app-setup-chart/templates/network-policy.yaml
@@ -7,15 +7,11 @@ spec:
   podSelector:
     matchLabels:
   ingress:
-  {{- if eq .Values.cloud "gcp" -}}
   - from:
     - podSelector: {}
     - namespaceSelector:
         matchLabels:
           name: nginx
-  {{- else -}}
-  - {}
-  {{- end -}}
   egress:
   - {}
   policyTypes:

--- a/terra-app-setup-chart/templates/network-policy.yaml
+++ b/terra-app-setup-chart/templates/network-policy.yaml
@@ -7,11 +7,15 @@ spec:
   podSelector:
     matchLabels:
   ingress:
+  {{- if eq .Values.cloud "gcp" -}}
   - from:
     - podSelector: {}
     - namespaceSelector:
         matchLabels:
           name: nginx
+  {{- else -}}
+  - {}
+  {{- end -}}
   egress:
   - {}
   policyTypes:

--- a/terra-app-setup-chart/templates/secrets.yaml
+++ b/terra-app-setup-chart/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cloud "gcp" -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ type: Opaque
 data:
 {{ (.Files.Glob "tls.crt").AsSecrets | indent 2 }}
 {{ (.Files.Glob "tls.key").AsSecrets | indent 2 }}
+{{- end -}}

--- a/terra-app-setup-chart/templates/service-account.yaml
+++ b/terra-app-setup-chart/templates/service-account.yaml
@@ -5,4 +5,8 @@ metadata:
   labels:
     leonardo: "true"
   annotations:
+    {{- if eq .Values.cloud "gcp" -}}
     iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.annotations.gcpServiceAccount | quote }}
+    {{- else -}}
+    azure.workload.identity/tenant-id: {{ .Values.serviceAccount.annotations.azureTenantId | quote }}
+    {{- end -}}

--- a/terra-app-setup-chart/templates/service-account.yaml
+++ b/terra-app-setup-chart/templates/service-account.yaml
@@ -5,4 +5,6 @@ metadata:
   labels:
     leonardo: "true"
   annotations:
+    {{- if eq .Values.cloud "gcp" -}}
     iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.annotations.gcpServiceAccount | quote }}
+    {{- end -}}

--- a/terra-app-setup-chart/templates/service-account.yaml
+++ b/terra-app-setup-chart/templates/service-account.yaml
@@ -5,8 +5,4 @@ metadata:
   labels:
     leonardo: "true"
   annotations:
-    {{- if eq .Values.cloud "gcp" -}}
     iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.annotations.gcpServiceAccount | quote }}
-    {{- else -}}
-    azure.workload.identity/tenant-id: {{ .Values.serviceAccount.annotations.azureTenantId | quote }}
-    {{- end -}}

--- a/terra-app-setup-chart/values.yaml
+++ b/terra-app-setup-chart/values.yaml
@@ -4,4 +4,3 @@ serviceAccount:
   name: "leonardo-app-ksa"
   annotations:
     gcpServiceAccount:
-    azureTenantId:

--- a/terra-app-setup-chart/values.yaml
+++ b/terra-app-setup-chart/values.yaml
@@ -1,4 +1,7 @@
+cloud: gcp
+
 serviceAccount:
   name: "leonardo-app-ksa"
   annotations:
     gcpServiceAccount:
+    azureTenantId:


### PR DESCRIPTION
Testing from Leo side.

Some things are similar (like Workload Identity) so my initial idea is to make the `terra-app-setup-chart` cloud agnostic instead of making a new version for Azure. Could revisit this though..