### PR TITLE
Fix typo -- insert newline

### DIFF
--- a/terra-app-setup-chart/templates/service-account.yaml
+++ b/terra-app-setup-chart/templates/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     leonardo: "true"
   annotations:
-    {{- if eq .Values.cloud "gcp" -}}
+    {{- if eq .Values.cloud "gcp" }}
     iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.annotations.gcpServiceAccount | quote }}
     {{- end -}}


### PR DESCRIPTION
Stupid ctmpl syntax. Before this wasn't rendering with a newline:
```
# Source: terra-app-setup/templates/service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "leonardo-app-ksa"
  labels:
    leonardo: "true"
  annotations:iam.gke.io/gcp-service-account:
```

After the fix:
```
# Source: terra-app-setup/templates/service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "leonardo-app-ksa"
  labels:
    leonardo: "true"
  annotations:
    iam.gke.io/gcp-service-account:
```