### PR TITLE
[AJ-822] Limit relaylistener requests/cpu

### DIFF
--- a/terra-app-setup-chart/Chart.yaml
+++ b/terra-app-setup-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: terra-app-setup
 description: Chart for set up entities for deploying Terra applications
 type: application
-version: 0.0.5
+version: 0.0.7

--- a/terra-app-setup-chart/templates/relay-listener-deployment.yaml
+++ b/terra-app-setup-chart/templates/relay-listener-deployment.yaml
@@ -22,6 +22,13 @@ spec:
           image: {{ .Values.relaylistener.image }}
           ports:
             - containerPort: {{ .Values.relaylistener.port }}
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
           env:
             - name: LISTENER_RELAYCONNECTIONSTRING
               value: {{ .Values.relaylistener.connectionString }}


### PR DESCRIPTION
Related to https://broadworkbench.atlassian.net/browse/AJ-822, we're trying to limit each Java container in Azure deployments and tune the node type, in an effort to improve capacity/performance.