### PR TITLE
[IA-4089] update access mode permissions to ReadWriteOnce

### DIFF
--- a/apps/cellxgene/app.yaml
+++ b/apps/cellxgene/app.yaml
@@ -10,5 +10,5 @@ services:
     command:  ["cellxgene"]
     args: ["launch", "--host", "0.0.0.0"]
     pdMountPath: "/data"
-    pdAccessMode: "ReadOnlyMany"
+    pdAccessMode: "ReadWriteOnce"
     environment: {} 

--- a/apps/cirrocumulus/app.yaml
+++ b/apps/cirrocumulus/app.yaml
@@ -10,5 +10,5 @@ services:
     command:  ["cirro"]
     args: ["launch", "--host", "0.0.0.0"]
     pdMountPath: "/data"
-    pdAccessMode: "ReadOnlyMany"
+    pdAccessMode: "ReadWriteOnce"
     environment: {} 


### PR DESCRIPTION
https://broadinstitute.slack.com/archives/GB1VAM14J/p1677508311726289

https://broadworkbench.atlassian.net/browse/IA-4089

It looks like the `uscs-genome` image does not exist anymore, causing the smoke test to fail