### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Checks-out repo under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup data for tests and perform system installs
         run: |


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- replace 'set-output' command