### PR TITLE
remove fullname override for RStudio app to avoid hard coded RStudio app name

### DIFF
--- a/terra-app-helm/aou-rstudio-chart/values.yaml
+++ b/terra-app-helm/aou-rstudio-chart/values.yaml
@@ -3,8 +3,6 @@ image:
   image: "us.gcr.io/broad-dsp-gcr-public/terra-rstudio-aou:0.1.1"
 
 imagePullSecrets: []
-nameOverride: aou-rstudio
-fullnameOverride: aou-rstudio
 
 # Provided by Leonardo
 serviceAccount:


### PR DESCRIPTION
We want to use release name for Rstudio apps. Then each Rstudio services & PVs would has it's unique name
https://github.com/DataBiosphere/terra-app/blob/main/terra-app-helm/aou-rstudio-chart/templates/_helpers.tpl#L19
