### PR TITLE
Set extraEnvs for RStudio app

### DIFF
--- a/terra-app-helm/aou-rstudio-chart/Chart.yaml
+++ b/terra-app-helm/aou-rstudio-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: aou-rstudio-chart
 description: Chart for deploying Rstudio to All of Us Workbench
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/terra-app-helm/aou-rstudio-chart/templates/deployment.yaml
+++ b/terra-app-helm/aou-rstudio-chart/templates/deployment.yaml
@@ -40,6 +40,13 @@ spec:
               - NET_ADMIN
           args: ["chown -R rstudio:users /home/rstudio && /init_aou"]
           command: ["/bin/sh", "-c"]
+          {{- if .Values.extraEnv }}
+          env:
+            {{- range .Values.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8787

--- a/terra-app-helm/aou-rstudio-chart/values.yaml
+++ b/terra-app-helm/aou-rstudio-chart/values.yaml
@@ -37,7 +37,11 @@ persistence:
   # size: 100G
   # gcePersistentDisk: "disk--test"
 
-# Welder env variables provided by Leonardo
+# Provided by Leonardo
+extraEnv:
+  # - name: WORKSPACE_NAME
+  #   value: my-workspace
+
 welder:
   extraEnv:
   # - name: GOOGLE_PROJECT


### PR DESCRIPTION
This is reverted at https://github.com/DataBiosphere/terra-app/pull/34/commits/f8135e45c034f10aba4a5f7c7cfba35a2a90c7e5
AoU needs to set few env vars for RStudio app, e.g. workspace namespace, owner_email, google_project 