### PR TITLE
RW-9840 RW-10463 add license as a secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tmp
 terra-app-setup-chart/repo
 terra-app-chart/repo
+*.jwt

--- a/terra-app-helm/aou-sas-chart/templates/deployment.yaml
+++ b/terra-app-helm/aou-sas-chart/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         - name: {{ include "app.fullname" . }}-storage
           persistentVolumeClaim:
             claimName: {{ include "app.fullname" . }}-pvc
+        - name: sas-licence-file
+          secret:
+            secretName: sas-licence
       containers:
         - name: wondershaper
           image: "us.gcr.io/broad-dsp-gcr-public/wondershaper:0.0.1"
@@ -52,8 +55,8 @@ spec:
               value: "0"
             - name: PRE_DEPLOY_SCRIPT
               value: 'sed -i "s/RequestHeader/#RequestHeader/g" /etc/httpd/conf.d/dkrapro-proxy.conf; echo ProxyPassReverseCookiePath /SASStudio /sas/SASStudio >> /etc/httpd/conf.d/dkrapro-proxy.conf; echo AddOutputFilterByType SUBSTITUTE text/html > /etc/httpd/conf.d/substitute.conf ; echo AddOutputFilterByType SUBSTITUTE text/css >> /etc/httpd/conf.d/substitute.conf; echo AddOutputFilterByType SUBSTITUTE application/x-javascript >> /etc/httpd/conf.d/substitute.conf; echo AddOutputFilterByType SUBSTITUTE application/javascript >> /etc/httpd/conf.d/substitute.conf;echo AddOutputFilterByType SUBSTITUTE text/xml >> /etc/httpd/conf.d/substitute.conf; echo Substitute "s|/SASStudio/|/sas/SASStudio/|n" >> /etc/httpd/conf.d/substitute.conf'
-            - name: SETINIT_TEXT
-              value: "{{ .Values.sasLicense }}"
+            - name: SASLICENSEFILE
+              value: SASLicense.jwt
             - name: JAVA_OPTION_SAS_COMMONS_WEB_SECURITY_CORS_ALLOWEDORIGINS
               value: "-Dsas.commons.web.security.cors.allowedOrigins=*"
             - name: JAVA_OPTION_SAS_COMMONS_WEB_SECURITY_CORS_ALLOWCREDENTIALS
@@ -71,6 +74,9 @@ spec:
           volumeMounts:
             - mountPath: "/data"
               name: {{ include "app.fullname" . }}-storage
+            - name: sas-licence-file
+              mountPath: "/opt/sas/viya/config/SASLicense.jwt"
+              subPath: SASLicense.jwt
           resources: {}
         - name: welder
           image: "us.gcr.io/broad-dsp-gcr-public/welder-server:6648f5c"

--- a/terra-app-helm/aou-sas-chart/templates/sas-secrets.yaml
+++ b/terra-app-helm/aou-sas-chart/templates/sas-secrets.yaml
@@ -5,3 +5,11 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sas-licence
+type: Opaque
+data:
+{{ (.Files.Glob "SASLicense.jwt").AsSecrets | indent 2 }}

--- a/terra-app-helm/aou-sas-chart/test_values.yaml
+++ b/terra-app-helm/aou-sas-chart/test_values.yaml
@@ -7,7 +7,6 @@ configs: {}
 serviceAccount:
   name: "test-service-account"
 
-sasLicense:
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-9840
https://precisionmedicineinitiative.atlassian.net/browse/RW-10463

This PR injects SAS license as a file via k8s secrets as opposed to a plain environment variable

This pattern is similar to how we inject leo cert files

If you'd like to try out helm install, try add the license file as `terra-app-helm/aou-sas-chart/SASLicense.jwt` once you have a license