### PR TITLE
Grant sas group members permission to all /data

### DIFF
--- a/terra-app-helm/aou-sas-chart/templates/deployment.yaml
+++ b/terra-app-helm/aou-sas-chart/templates/deployment.yaml
@@ -63,7 +63,8 @@ spec:
                 echo AddOutputFilterByType SUBSTITUTE application/javascript >> /etc/httpd/conf.d/substitute.conf;
                 echo AddOutputFilterByType SUBSTITUTE text/xml >> /etc/httpd/conf.d/substitute.conf; 
                 echo Substitute "s|/SASStudio/|"{{ .Values.ingress.proxyPath }}"/SASStudio/|n" >> /etc/httpd/conf.d/substitute.conf; 
-                useradd -m -d /data -g sas -s /bin/bash aou; echo "aou:aou" | chpasswd
+                useradd -m -d /data -g sas -s /bin/bash aou; echo "aou:aou" | chpasswd;
+                chmod -R g+rwx /data
             - name: SASLICENSEFILE
               value: SASLicense.jwt
             - name: JAVA_OPTION_SAS_COMMONS_WEB_SECURITY_CORS_ALLOWEDORIGINS


### PR DESCRIPTION
Saw many 403/404 errors in my sas browser. 
And I saw 
`Cannot open %INCLUDE file /data/.sasstudio5/.autoexec.sas.` error in GCP console log

![Screenshot 2023-09-29 at 3 37 20 PM](https://github.com/DataBiosphere/terra-app/assets/6351731/25b58808-95b4-4680-881b-63aec0fd8dff)

This PR grants all members in SAS group has access to /data folder